### PR TITLE
🔄 Extension du support pour plusieurs tokens en arguments

### DIFF
--- a/.github/workflows/deploy_eirlab_cloud.yml
+++ b/.github/workflows/deploy_eirlab_cloud.yml
@@ -78,4 +78,4 @@ jobs:
             cd ~/wolf/wolf
             poetry install
             deactivate
-            echo "${{ secrets.SUDO_PASSWORD }}" | sudo -S python3 install.py
+            echo "${{ secrets.SUDO_PASSWORD }}" | sudo -S python3 install.py --notion ${{ secrets.NOTION_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ git clone git@github.com:eirlab/wolf.git
 
 ### Installation pour les utilisateurs
 
-Créez un environnement virtuel et installez le package `wolf_core` :
+Créez un environnement virtuel et installez le package :
 
 ```bash
 python3 -m pip install virtualenv
 python3 -m virtualenv venv
 source venv/bin/activate
-pip install 'wolf_core @ git+https://github.com/Eirlab/wolf-core.git'
+pip install poetry
+poetry install
 
 ```
 
@@ -61,19 +62,22 @@ poetry install
 
 ### Configuration
 
-Le projet utilise un fichier de configuration pour définir les paramètres de connexion aux différents outils. Vous devez
-créer un fichier de configuration à placer dans le répertoire wolf nommé `token.json` ayant le format suivant :
+Le projet utilise les arguments de la ligne de commande pour définir les paramètres de connexion à divers outils. Vous pouvez placer vos tokens directement via les arguments de la
+ligne de commande.
 
-```json
-{
-  "notion": "SECRET_HERE",
-  "dolibarr": "SECRET_HERE"
-}
+```bash
+python install.py --token1 VOTRE_TOKEN1 --token2 VOTRE_TOKEN2 ...
 ```
 
-Attention, ce fichier ne doit pas être versionné ! Vous devez donc l'ajouter au fichier `.gitignore` du projet.
+N'oubliez pas de remplacer VOTRE_NOTION_TOKEN et VOTRE_DOLIBARR_TOKEN par vos véritables tokens.
+Vous pouvez également placer vos tokens dans le fichier `install.py`.
 
-Une fois l'installation terminée, vous pouvez commencer à utiliser le projet Wolf.
+Pour enregistrer la configuration et lancer le projet en tant que service systemd, exécutez la commande suivante :
+
+```bash
+deactivate
+sudo python3 install.py
+```
 
 ## Documentation
 
@@ -81,7 +85,7 @@ La documentation complète du projet est disponible dans le répertoire /docs. V
 pour en savoir plus sur les
 fonctionnalités du projet et son utilisation.
 
-La documentation est disponibe en ligne à l'adresse suivante : https://wolf-eirlab-community.readthedocs.io/
+La documentation est disponible en ligne à l'adresse suivante : https://wolf-eirlab-community.readthedocs.io/
 
 ## Contributions
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,16 +1,33 @@
 Installation
 ============
 
-Pour installer le projet, il faut d'abord cloner le projet sur votre machine:
+Pour installer le projet, suivez les instructions ci-dessous :
+
+Clonez le projet sur votre machine en utilisant la commande suivante :
+bash
 
 ```bash
 git clone git@github.com:eirlab/wolf.git
 ```
 
+Installation pour les utilisateurs
+----------------------------------
+
+Créez un environnement virtuel et installez le package :
+
+```bash
+python3 -m pip install virtualenv
+python3 -m virtualenv venv
+source venv/bin/activate
+pip install poetry
+poetry install
+
+```
+
 Installation pour les développeurs
 ----------------------------------
 
-Le projet est basé sur les submodules git, il faut donc initialiser les submodules:
+Le projet utilise des submodules Git, vous devez donc les initialiser comme suit :
 
 ```bash
 git submodule init
@@ -19,7 +36,7 @@ cd core
 git checkout main
 ```
 
-Ensuite, il faut installer les dépendances du projet et installer le package `wolf_core` :
+Ensuite, installez les dépendances du projet et le package wolf_core :
 
 ```bash
 python3 -m pip install virtualenv
@@ -30,14 +47,23 @@ cd core
 poetry install
 ```
 
-Installation pour les utilisateurs
-----------------------------------
+Configuration
+-------------
 
-Créez un environnement virtuel et installez le package `wolf_core` :
+Le projet utilise les arguments de la ligne de commande pour définir les paramètres de connexion à divers outils.
+Vous pouvez placer vos tokens directement via les arguments de la
+ligne de commande.
 
 ```bash
-python3 -m pip install virtualenv
-python3 -m virtualenv venv
-source venv/bin/activate
-pip install 'wolf_core @ git+https://github.com/Eirlab/wolf-core.git' 
+python install.py --token1 VOTRE_TOKEN1 --token2 VOTRE_TOKEN2 ...
+```
+
+N'oubliez pas de remplacer VOTRE_NOTION_TOKEN et VOTRE_DOLIBARR_TOKEN par vos véritables tokens.
+Vous pouvez également placer vos tokens dans le fichier `install.py`.
+
+Pour enregistrer la configuration et lancer le projet en tant que service systemd, exécutez la commande suivante :
+
+```bash
+deactivate
+sudo python3 install.py
 ```

--- a/wolf/install.py
+++ b/wolf/install.py
@@ -16,6 +16,7 @@ sensitive token information into a standalone JSON file. As a security measure, 
 dynamically and securely, not hardcoded. Also, the script should be run with sufficient permissions, usually as root
 or via sudo, to allow the creation/modification of system services.
 """
+import argparse
 import getpass
 import json
 import os
@@ -83,9 +84,33 @@ def create_token_file(token_dict, file_path='token.json'):
     print(f"token.json created at {file_path}.")
 
 
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+
+    # You can specify some known arguments, e.g., service_name in this case
+    unknown_args = parser.parse_known_args()
+    print(unknown_args)
+
+    # Convert unknown args to token dictionary
+    token_dict = {}
+    for arg in unknown_args[1]:
+        if arg.startswith('--'):
+            key = arg[2:]
+            value = unknown_args[1][unknown_args[1].index(arg) + 1]
+            token_dict[key] = value
+
+    return unknown_args[0], token_dict
+
+
 if __name__ == "__main__":
+    args = parse_arguments()
+    # check if args is not empty
+    if args[1]:
+        token_dict = args[1]
+    else:
+        # Needs to be replaced with the actual token. KEEP SECRET AND NEVER COMMIT TO GIT!
+        token_dict = {"app": "token"}
     service_name = 'wolf.service'
-    token_dict = {"app": "token"}  # Needs to be replaced with the actual token. KEEP SECRET AND NEVER COMMIT TO GIT!
 
     create_service(service_name=service_name)
     create_token_file(token_dict)


### PR DESCRIPTION
Cette demande de tirage (Pull Request) propose une mise à jour significative de l'interface en ligne de commande de l'application. L'objectif de ce changement est d'améliorer la flexibilité et l'évolutivité de l'application en ce qui concerne la gestion des tokens.

## 📝 Changements

Avec la mise à jour, l'application sera désormais capable de gérer un nombre quelconque de tokens, que ce soit `notion_token`, `dolibarr_token`, `github_doc_latex_token` ou `github_doc_publish_token`, etc., passés en arguments de ligne de commande.

Ces tokens sont inclus dans les arguments inconnus, qui sont ensuite convertis au format de dictionnaire (`clé : valeur`). Par exemple, `--notion_token abc` serait donc stocké comme `{"notion_token": "abc"}`.

## ✨ Avantages

Cette fonctionnalité offre un avantage en termes d'évolutivité, car nous pouvons potentiellement gérer un nombre quelconque de tokens variés sans apporter de modifications significatives à l'architecture de l'application, tout en conservant la lisibilité et la facilité d'utilisation.

## 🛡️ Considérations supplémentaires

Bien que ce concept fonctionne bien, il faut également tenir compte des implications de sécurité du passage des tokens en arguments de ligne de commande. Généralement, il est préférable d'utiliser des méthodes sécurisées pour fournir des données sensibles (comme des tokens) aux applications, et passer des tokens dans les arguments de ligne de commande peut ne pas être la meilleure pratique dans les environnements de production. Une approche combinant les deux méthodes pourrait être envisagée en fonction du cas d'utilisation et des contraintes de sécurité.